### PR TITLE
Do not allow a negative indentLevel to throw RangeError: Invalid arra…

### DIFF
--- a/js/jsonlint/jsl.format.js
+++ b/js/jsonlint/jsl.format.js
@@ -8,6 +8,7 @@ var jsl = typeof jsl === 'undefined' ? {} : jsl;
 jsl.format = (function () {
 
     function repeat(s, count) {
+        count = count < 0 ? 0 : count;
         return new Array(count + 1).join(s);
     }
 


### PR DESCRIPTION
Just realised I forgot to PR this. It's an upstream bug in jsonlint, see https://github.com/zaach/jsonlint/pull/73

Simplest replication I can find:

```
{
        "key": "value"
}
}
}
```

Which gives `Uncaught TypeError: Cannot read property 'top' of undefined` from main.js:1186. I've not checked other browsers but as it's a bug in jsonlint itself I'm sure it will be present.

My fix is to force the count value to zero inside jsl.format.repeat if it happens to be negative.